### PR TITLE
Added option to purge remaining devices

### DIFF
--- a/netbox_agent/config.py
+++ b/netbox_agent/config.py
@@ -28,6 +28,8 @@ def get_config():
     p.add_argument('--update-inventory', action='store_true', help='Update inventory')
     p.add_argument('--update-location', action='store_true', help='Update location')
     p.add_argument('--update-psu', action='store_true', help='Update PSU')
+    p.add_argument('--purge-old-devices', action='store_true',
+                   help='Purge existing (old ?) devices having same name but different serial')
 
     p.add_argument('--log_level', default='debug')
     p.add_argument('--netbox.url', help='Netbox URL')

--- a/netbox_agent/server.py
+++ b/netbox_agent/server.py
@@ -228,6 +228,13 @@ class ServerBase():
         )
         return new_blade
 
+    def _netbox_deduplicate_server(self):
+        serial = self.get_service_tag()
+        hostname = self.get_hostname()
+        server = nb.dcim.devices.get(name=hostname)
+        if server and server.serial != serial:
+            server.delete()
+
     def _netbox_create_server(self, datacenter, tenant, rack):
         device_role = get_device_role(config.device.server_role)
         device_type = get_device_type(self.get_product_name())
@@ -335,6 +342,9 @@ class ServerBase():
         datacenter = self.get_netbox_datacenter()
         rack = self.get_netbox_rack()
         tenant = self.get_netbox_tenant()
+
+        if config.purge_old_devices:
+            self._netbox_deduplicate_server()
 
         if self.is_blade():
             chassis = nb.dcim.devices.get(


### PR DESCRIPTION
This patch adds an option to clear remaining devices in the context of a new device replacing an old one with the same name but with a different hardware.

The serial leading to the bug is described below:

- A first server is registered under name `A` with serial `X`
- A second server is registered under name `B` with serial `Y`
- The server with serial `X` is decomissionned, but not removed
- The server with serial `Y` is reinstalled with name `A`

In this case, a device with serial `X` is well found, and netbox agent tries to update its name. But this raises an error because of the unique constraint on name, as another device already holds this name.

The proposed solution to handle this situation is to delete any device with same `name` but different `serial` before handling a device.

As this is not necessarily the expected behavior, it can be enabled by using the `--purge-old-devices` to avoid breaking existing inventory.