### PR TITLE
Netbox>=2.9 and pynetbox>=6 integration

### DIFF
--- a/netbox_agent/misc.py
+++ b/netbox_agent/misc.py
@@ -2,6 +2,8 @@ import socket
 import subprocess
 from shutil import which
 
+from slugify import slugify
+
 from netbox_agent.config import netbox_instance as nb
 
 
@@ -60,6 +62,7 @@ def get_hostname(config):
 
 
 def create_netbox_tags(tags):
+    ret = []
     for tag in tags:
         nb_tag = nb.extras.tags.get(
             name=tag
@@ -67,5 +70,7 @@ def create_netbox_tags(tags):
         if not nb_tag:
             nb_tag = nb.extras.tags.create(
                 name=tag,
-                slug=tag,
+                slug=slugify(tag),
             )
+        ret.append(nb_tag)
+    return ret

--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -56,6 +56,13 @@ class Network(object):
 
             ip_addr = netifaces.ifaddresses(interface).get(netifaces.AF_INET, [])
             ip6_addr = netifaces.ifaddresses(interface).get(netifaces.AF_INET6, [])
+            if config.network.ignore_ips:
+                for i, ip in enumerate(ip_addr):
+                    if re.match(config.network.ignore_ips, ip['addr']):
+                        ip_addr.pop(i)
+                for i, ip in enumerate(ip6_addr):
+                    if re.match(config.network.ignore_ips, ip['addr']):
+                        ip6_addr.pop(i)
 
             # netifaces returns a ipv6 netmask that netaddr does not understand.
             # this strips the netmask down to the correct format for netaddr,
@@ -77,15 +84,11 @@ class Network(object):
                 addr["netmask"] = addr["netmask"].split('/')[0]
                 ip_addr.append(addr)
 
-            if config.network.ignore_ips and ip_addr:
-                for i, ip in enumerate(ip_addr):
-                    if re.match(config.network.ignore_ips, ip['addr']):
-                        ip_addr.pop(i)
-
             mac = open('/sys/class/net/{}/address'.format(interface), 'r').read().strip()
             vlan = None
             if len(interface.split('.')) > 1:
                 vlan = int(interface.split('.')[1])
+
             bonding = False
             bonding_slaves = []
             if os.path.isdir('/sys/class/net/{}/bonding'.format(interface)):
@@ -209,8 +212,12 @@ class Network(object):
         update = False
         vlan_id = nic['vlan']
         lldp_vlan = self.lldp.get_switch_vlan(nic['name']) if config.network.lldp else None
+        # For strange reason, we need to get the object from scratch
+        # The object returned by pynetbox's save isn't always working (since pynetbox 6)
+        interface = nb.dcim.interfaces.get(id=interface.id)
 
-        # if local interface isn't a interface vlan or lldp doesn't report a vlan-id
+        # Handle the case were the local interface isn't an interface vlan as reported by Netbox
+        # and that LLDP doesn't report a vlan-id
         if vlan_id is None and lldp_vlan is None and \
            (interface.mode is not None or len(interface.tagged_vlans) > 0):
             logging.info('Interface {interface} is not tagged, reseting mode'.format(
@@ -219,13 +226,16 @@ class Network(object):
             interface.mode = None
             interface.tagged_vlans = []
             interface.untagged_vlan = None
-        # if it's a vlan interface
+        # if the local interface is configured with a vlan, it's supposed to be taggued
+        # if mode is either not set or not correctly configured or vlan are not
+        # correctly configured, we reset the vlan
         elif vlan_id and (
                 interface.mode is None or
                 type(interface.mode) is not int and (
+                    hasattr(interface.mode, 'value') and
                     interface.mode.value == self.dcim_choices['interface:mode']['Access'] or
                     len(interface.tagged_vlans) != 1 or
-                    interface.tagged_vlans[0].vid != vlan_id)):
+                    int(interface.tagged_vlans[0].vid) != int(vlan_id))):
             logging.info('Resetting tagged VLAN(s) on interface {interface}'.format(
                 interface=interface))
             update = True
@@ -233,7 +243,7 @@ class Network(object):
             interface.mode = self.dcim_choices['interface:mode']['Tagged']
             interface.tagged_vlans = [nb_vlan] if nb_vlan else []
             interface.untagged_vlan = None
-        # if lldp reports a vlan-id with pvid
+        # Finally if LLDP reports a vlan-id with the pvid attribute
         elif lldp_vlan:
             pvid_vlan = [key for (key, value) in lldp_vlan.items() if value['pvid']]
             if len(pvid_vlan) > 0 and (
@@ -271,7 +281,7 @@ class Network(object):
 
         if nic['vlan']:
             nb_vlan = self.get_or_create_vlan(nic['vlan'])
-            interface.mode = 200
+            interface.mode = self.dcim_choices['interface:mode']['Tagged']
             interface.tagged_vlans = [nb_vlan.id]
             interface.save()
         elif config.network.lldp and self.lldp.get_switch_vlan(nic['name']) is not None:
@@ -315,16 +325,24 @@ class Network(object):
         netbox_ips = nb.ipam.ip_addresses.filter(
             address=ip,
         )
+        netbox_ips = nb.ipam.ip_addresses.filter(
+            address=ip,
+        )
         if not len(netbox_ips):
             logging.info('Create new IP {ip} on {interface}'.format(
                 ip=ip, interface=interface))
+            query_params = {
+                'address': ip,
+                'status': "active",
+                'assigned_object_type': self.assigned_object_type,
+                'assigned_object_id': interface.id
+            }
+
             netbox_ip = nb.ipam.ip_addresses.create(
-                address=ip,
-                interface=interface.id,
-                status=1,
+                **query_params
             )
         else:
-            netbox_ip = netbox_ips[0]
+            netbox_ip = next(netbox_ips)
             # If IP exists in anycast
             if netbox_ip.role and netbox_ip.role.label == 'Anycast':
                 logging.debug('IP {} is Anycast..'.format(ip))
@@ -340,30 +358,40 @@ class Network(object):
                 # or if everything is assigned to other servers
                 elif not len(assigned_anycast_ip):
                     logging.info('Creating Anycast IP {} and assigning it to interface'.format(ip))
-                    netbox_ip = nb.ipam.ip_addresses.create(
-                        address=ip,
-                        interface=interface.id,
-                        status=1,
-                        role=self.ipam_choices['ip-address:role']['Anycast'],
-                        tenant=self.tenant.id if self.tenant else None,
-                    )
+                    query_params = {
+                        "address": ip,
+                        "status": "active",
+                        "role": self.ipam_choices['ip-address:role']['Anycast'],
+                        "tenant": self.tenant.id if self.tenant else None,
+                        "assigned_object_type": self.assigned_object_type,
+                        "assigned_object_id": interface.id
+                    }
+                    netbox_ip = nb.ipam.ip_addresses.create(**query_params)
                 return netbox_ip
             else:
-                if netbox_ip.interface is None:
+                if getattr(netbox_ip, 'interface', None) is None or \
+                   getattr(netbox_ip, 'assigned_object', None) is None:
                     logging.info('Assigning existing IP {ip} to {interface}'.format(
                         ip=ip, interface=interface))
-                elif netbox_ip.interface.id != interface.id:
+                elif getattr(netbox_ip, 'interface') and \
+                        netbox_ip.interface.id != interface.id or \
+                        hasattr(netbox_ip, 'assigned_object') and \
+                        netbox_ip.assigned_object_id != interface.id:
+
+                    old_interface = getattr(netbox_ip, "assigned_object", "n/a")
                     logging.info(
                         'Detected interface change for ip {ip}: old interface is '
                         '{old_interface} (id: {old_id}), new interface is {new_interface} '
                         ' (id: {new_id})'
                         .format(
-                            old_interface=netbox_ip.interface, new_interface=interface,
+                            old_interface=old_interface, new_interface=interface,
                             old_id=netbox_ip.id, new_id=interface.id, ip=netbox_ip.address
                         ))
                 else:
                     return netbox_ip
-                netbox_ip.interface = interface
+
+                netbox_ip.assigned_object_type = self.assigned_object_type
+                netbox_ip.assigned_object_id = interface.id
                 netbox_ip.save()
         return netbox_ip
 
@@ -373,9 +401,9 @@ class Network(object):
         logging.debug('Creating/Updating NIC...')
 
         # delete unknown interface
-        nb_nics = self.get_netbox_network_cards()
+        nb_nics = list(self.get_netbox_network_cards())
         local_nics = [x['name'] for x in self.nics]
-        for nic in nb_nics[:]:
+        for nic in nb_nics:
             if nic.name not in local_nics:
                 logging.info('Deleting netbox interface {name} because not present locally'.format(
                     name=nic.name
@@ -386,16 +414,19 @@ class Network(object):
         # delete IP on netbox that are not known on this server
         if len(nb_nics):
             netbox_ips = nb.ipam.ip_addresses.filter(
-                interface_id=[x.id for x in nb_nics],
+                **{self.intf_type: [x.id for x in nb_nics]}
             )
+
+            netbox_ips = list(netbox_ips)
             all_local_ips = list(chain.from_iterable([
                 x['ip'] for x in self.nics if x['ip'] is not None
             ]))
             for netbox_ip in netbox_ips:
                 if netbox_ip.address not in all_local_ips:
                     logging.info('Unassigning IP {ip} from {interface}'.format(
-                        ip=netbox_ip.address, interface=netbox_ip.interface))
-                    netbox_ip.interface = None
+                        ip=netbox_ip.address, interface=netbox_ip.assigned_object))
+                    netbox_ip.assigned_object_type = None
+                    netbox_ip.assigned_object_id = None
                     netbox_ip.save()
 
         # update each nic
@@ -417,12 +448,13 @@ class Network(object):
             ret, interface = self.reset_vlan_on_interface(nic, interface)
             nic_update += ret
 
-            _type = self.get_netbox_type_for_nic(nic)
-            if not interface.type or \
-               _type != interface.type.value:
-                logging.info('Interface type is wrong, resetting')
-                interface.type = _type
-                nic_update += 1
+            if hasattr(interface, 'type'):
+                _type = self.get_netbox_type_for_nic(nic)
+                if not interface.type or \
+                   _type != interface.type.value:
+                    logging.info('Interface type is wrong, resetting')
+                    interface.type = _type
+                    nic_update += 1
 
             if hasattr(interface, 'lag') and interface.lag is not None:
                 local_lag_int = next(
@@ -465,6 +497,8 @@ class ServerNetwork(Network):
         self.nb_net = nb.dcim
         self.custom_arg = {'device': getattr(self.device, "id", None)}
         self.custom_arg_id = {'device_id': getattr(self.device, "id", None)}
+        self.intf_type = "interface_id"
+        self.assigned_object_type = "dcim.interface"
 
     def get_network_type(self):
         return 'server'
@@ -485,7 +519,7 @@ class ServerNetwork(Network):
             return nb_server_interface
 
         try:
-            nb_switch = nb_mgmt_ip.interface.device
+            nb_switch = nb_mgmt_ip.assigned_object.device
             logging.info('Found a switch in Netbox based on LLDP infos: {} (id: {})'.format(
                 switch_ip,
                 nb_switch.id
@@ -585,6 +619,8 @@ class VirtualNetwork(Network):
         self.nb_net = nb.virtualization
         self.custom_arg = {'virtual_machine': getattr(self.device, "id", None)}
         self.custom_arg_id = {'virtual_machine_id': getattr(self.device, "id", None)}
+        self.intf_type = "vminterface_id"
+        self.assigned_object_type = "virtualization.vminterface"
 
         dcim_c = nb.virtualization.interfaces.choices()
         for _choice_type in dcim_c:

--- a/netbox_agent/power.py
+++ b/netbox_agent/power.py
@@ -51,7 +51,7 @@ class PowerSupply():
         )
 
     def create_or_update_power_supply(self):
-        nb_psus = self.get_netbox_power_supply()
+        nb_psus = list(self.get_netbox_power_supply())
         psus = self.get_power_supply()
 
         # Delete unknown PSU


### PR DESCRIPTION
This patch integrates the work done by @solvik started in https://github.com/Solvik/netbox-agent/pull/177, and adds a couple of fixes:

- Fixed the expansion bays inventory (drive bay was receiving the internal GPU)
- Enhanced the GPUs inventory by comparing per product count (as serial is not available everywhere) to detect hardware changes
- Made some expressions a little bit more readable
- Fixed some `if` expressions leading to exception because too large filter